### PR TITLE
Added new Fastly domain - fastlylb.net

### DIFF
--- a/lib/guesscnamecdn.js
+++ b/lib/guesscnamecdn.js
@@ -43,6 +43,7 @@ var CDN_PROVIDER  = [
   [".gccdn.net", "CDNetworks"],
   [".gccdn.cn", "CDNetworks"],
   [".fastly.net", "Fastly"],
+  [".fastlylb.net", "Fastly"],
   [".gslb.taobao.com", "Taobao"],
   [".gslb.tbcache.com", "Alimama"],
   [".ccgslb.com", "ChinaCache"],


### PR DESCRIPTION
Fastly now uses fastlylb.net in some records.  Added so it's recognized.